### PR TITLE
[WIP] Arm64 support

### DIFF
--- a/c_src/arm64.patch
+++ b/c_src/arm64.patch
@@ -1,0 +1,34 @@
+diff --git a/port/atomic_pointer.h b/port/atomic_pointer.h
+index 2b485c7..ed7dcff 100644
+--- a/port/atomic_pointer.h
++++ b/port/atomic_pointer.h
+@@ -36,6 +36,8 @@
+ #define ARCH_CPU_X86_FAMILY 1
+ #elif defined(__ARMEL__)
+ #define ARCH_CPU_ARM_FAMILY 1
++#elif defined(__aarch64__)
++#define ARCH_CPU_ARM64_FAMILY 1
+ #endif
+ 
+ namespace leveldb {
+@@ -91,6 +93,12 @@ inline void MemoryBarrier() {
+ }
+ #define LEVELDB_HAVE_MEMORY_BARRIER
+ 
++#elif defined(ARCH_CPU_ARM64_FAMILY)
++ inline void MemoryBarrier() {
++   asm volatile("dmb sy" : : : "memory");
++ }
++#define LEVELDB_HAVE_MEMORY_BARRIER
++
+ #endif
+ 
+ // AtomicPointer built using platform-specific MemoryBarrier()
+@@ -147,6 +155,7 @@ class AtomicPointer {
+ #undef LEVELDB_HAVE_MEMORY_BARRIER
+ #undef ARCH_CPU_X86_FAMILY
+ #undef ARCH_CPU_ARM_FAMILY
++#undef ARCH_CPU_ARM64_FAMILY
+ 
+ }  // namespace port
+ }  // namespace leveldb

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -61,6 +61,7 @@ case "$1" in
             if [ "$BASHO_EE" = "1" ]; then
                 (cd leveldb && git submodule update --init)
             fi
+            (cd leveldb; patch -p1 < ../arm64.patch)
         fi
         ;;
 


### PR DESCRIPTION
arm64 needs an especific memory boundary cpy syscall this adds it. Reimplemented based  on the upstream change https://github.com/google/leveldb/commit/c4c38f9c1f3bb405fe22a79c5611438f91208d09.patch )